### PR TITLE
Fix error on loading setting yaml file on repository.

### DIFF
--- a/github/rulefile.go
+++ b/github/rulefile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 
@@ -25,9 +26,13 @@ func (c *Client) RuleFile(ctx context.Context, u string) (*rule.Rule, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&content); err != nil {
 		return nil, fmt.Errorf("Failed to decode response: %w", err)
 	}
+	data, err := base64.StdEncoding.DecodeString(content.Content)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to decode content: %w", err)
+	}
 
 	var r rule.Rule
-	if err := yaml.Unmarshal([]byte(content.Content), &r); err != nil {
+	if err := yaml.Unmarshal(data, &r); err != nil {
 		return nil, fmt.Errorf("Failed to unmarshal yaml: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes the error on loading setting YAML file on a repository.
Loading the setting always failed because try to parse yaml for base64 encoded content.

When getting content from GitHub content API, we need to base64 decode `content` in the response.
https://docs.github.com/en/rest/reference/repos#contents