### PR TITLE
Fix typo in Rule struct definition.

### DIFF
--- a/rule/rule.go
+++ b/rule/rule.go
@@ -35,7 +35,7 @@ type ReleaseNote struct {
 
 type Rule struct {
 	Validation  ValidateRule `yaml:"validation"`
-	ReleaseNote ReleaseNote  `yaml:"relasenote"`
+	ReleaseNote ReleaseNote  `yaml:"releasenote"`
 }
 
 func (r *Rule) ValidateTitle(title string) error {


### PR DESCRIPTION
## Summary

This PR fixes typo in Rule struct definition. `s/relasenote/releasenote/`