### PR TITLE
Implement validation filter branch and slack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,29 @@ validation:
       values:
         - "# Why do we need this change"
         - "# What change do you intend to"
+  branches:
+    - feature/*
 releasenote:
   branches:
     - deployment/production
   tags:
     - v[0-9]+.[0-9]+.[0-9]+
-  integration:
-    slack: "[slack-incoming-webhook-url]"
+integration:
+  slack: "[slack-incoming-webhook-url]"
 ```
 
-`.doorkeeper.yml` can define validation and relesenote configuration.
+You can configure webhook behavior in root of `.doorkeeper.yml`. This file is able to have three root section
 
-On `validation` section, you can declare verification rule in array of `kind` and `values` object.
-Full validation configuration examples are following:
+### validation field
+
+| kind                | value type        | value description               | behaves                                                   |
+|:--------------------|:------------------|:--------------------------------|:----------------------------------------------------------|
+| branches            | array of string   | string or regexp string         | exact branch name or regular expression to run validation |
+| title               | array of object   | have kind and value field       | validation setting for pullrequest title                  |
+| description         | array of object   | have kind and value field       | validation setting for pullrequest title                  |
+
+On `title` and `description` section, you can declare verification rule in array of `kind` and `values` object.
+Validation rule configuration examples are following:
 
 
 | kind      | values operator | value type                      | behaves                                                 |
@@ -67,13 +77,22 @@ Full validation configuration examples are following:
 | contains  | AND             | string                          | string MUST contain all of list values                  |
 | blacklist | AND             | string                          | string MUST NOT be equals to blacklist strings          |
 
-And `releasenote` section, you can declare execute making relasenote branch, tag, and integration setting.
+### relasenote field
+
+On `releasenote` field, you can declare execute making relasenote branch, tag, and integration setting.
 Full validation configuration examples are following:
 
-| kind                | value type        | value type                      | behaves                                                   |
-|:--------------------|:------------------|:--------------------------------|:----------------------------------------------------------|
-| branches            | array of string   | string or regexp string         | exact brnach name or regular expression                   |
-| tags                | array of string   | regexp string                   | tag format matching regular expression                    |
+| kind                | value type        | value type                      | behaves                                                        |
+|:--------------------|:------------------|:--------------------------------|:---------------------------------------------------------------|
+| branches            | array of string   | string or regexp string         | exact brnach name or regular expression to factory releasenote |
+| tags                | array of string   | regexp string                   | tag format matching regular expression                         |
+
+### integration field
+
+On `integration` field, you can declare notification setting for validation and releasenote process result.
+Currently, only supports `slack` integration.
+
+
 | integrations        | map[string]string | -                               | -                                                         |
 | integrations[key]   | string            | integration type string         | Currently support `slack` only                            |
 | integrations[value] | string            | integration value string        | on `slack` type, value must be valid incoming-webhook URL |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can configure webhook behavior in root of `.doorkeeper.yml`. This file is ab
 
 ### validation field
 
-| kind                | value type        | value description               | behaves                                                   |
+| key                 | value type        | value description               | behaves                                                   |
 |:--------------------|:------------------|:--------------------------------|:----------------------------------------------------------|
 | branches            | array of string   | string or regexp string         | exact branch name or regular expression to run validation |
 | title               | array of object   | have kind and value field       | validation setting for pullrequest title                  |
@@ -82,7 +82,7 @@ Validation rule configuration examples are following:
 On `releasenote` field, you can declare execute making relasenote branch, tag, and integration setting.
 Full validation configuration examples are following:
 
-| kind                | value type        | value type                      | behaves                                                        |
+| key                 | value type        | value description                      | behaves                                                        |
 |:--------------------|:------------------|:--------------------------------|:---------------------------------------------------------------|
 | branches            | array of string   | string or regexp string         | exact brnach name or regular expression to factory releasenote |
 | tags                | array of string   | regexp string                   | tag format matching regular expression                         |
@@ -93,6 +93,8 @@ On `integration` field, you can declare notification setting for validation and 
 Currently, only supports `slack` integration.
 
 
+| key                 | value type        | value description                      | behaves                                                        |
+|:--------------------|:------------------|:--------------------------------|:---------------------------------------------------------------|
 | integrations        | map[string]string | -                               | -                                                         |
 | integrations[key]   | string            | integration type string         | Currently support `slack` only                            |
 | integrations[value] | string            | integration value string        | on `slack` type, value must be valid incoming-webhook URL |

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,12 @@ func main() {
 	if v := os.Getenv("PORT"); v != "" {
 		port = v
 	}
-	if err := http.ListenAndServe(":"+port, handler.WebhookHandler("/webhook", nil)); err != nil {
+
+	log.Printf("Server starts on :%s", port)
+	if err := http.ListenAndServe(
+		":"+port,
+		handler.WebhookHandler("/webhook", nil),
+	); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/handler/push.go
+++ b/handler/push.go
@@ -1,15 +1,11 @@
 package handler
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log"
 	"strings"
 	"time"
-
-	"encoding/json"
-	"net/http"
 
 	"github.com/ysugimoto/doorkeeper/entity"
 	"github.com/ysugimoto/doorkeeper/github"
@@ -93,27 +89,4 @@ func processTagPushEvent(c *github.Client, evt entity.GithubPushEvent, r *rule.R
 			}
 		}
 	}
-}
-
-func sendToSlack(ctx context.Context, webhookURL, message string) error {
-	body, err := json.Marshal(map[string]string{
-		"text": message,
-	})
-	if err != nil {
-		return fmt.Errorf("Failed to marshal body: %w", err)
-	}
-
-	c, timeout := context.WithTimeout(ctx, 5*time.Second)
-	defer timeout()
-
-	req, err := http.NewRequestWithContext(c, http.MethodPost, webhookURL, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("Failed to make slack request: %w", err)
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("Failed to get slack response: %w", err)
-	}
-	resp.Body.Close()
-	return nil
 }

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -24,6 +24,7 @@ type ValidateRule struct {
 	Disable     bool       `yaml:"disable"`
 	Title       []RuleItem `yaml:"title"`
 	Description []RuleItem `yaml:"description"`
+	Branches    []string   `yaml:"branches"`
 }
 
 type ReleaseNote struct {
@@ -56,7 +57,15 @@ func (r *Rule) ValidateDescription(desc string) error {
 	return nil
 }
 
-func (r *Rule) MatchBranch(branch string) (bool, error) {
+func (r *Rule) MatchValidateBranch(branch string) (bool, error) {
+	return r.matchBranch(branch, r.Validation.Branches)
+}
+
+func (r *Rule) MatchReleaseNoteBranch(branch string) (bool, error) {
+	return r.matchBranch(branch, r.ReleaseNote.Branches)
+}
+
+func (r *Rule) matchBranch(branch string, targets []string) (bool, error) {
 	for i := range r.ReleaseNote.Branches {
 		if matched, err := regexp.MatchString(r.ReleaseNote.Branches[i], branch); err != nil {
 			return false, err

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -28,15 +28,15 @@ type ValidateRule struct {
 }
 
 type ReleaseNote struct {
-	Disable     bool              `yaml:"disable"`
-	Branches    []string          `yaml:"branches"`
-	Tags        []string          `yaml:"tags"`
-	Integration map[string]string `yaml:"integration"`
+	Disable  bool     `yaml:"disable"`
+	Branches []string `yaml:"branches"`
+	Tags     []string `yaml:"tags"`
 }
 
 type Rule struct {
-	Validation  ValidateRule `yaml:"validation"`
-	ReleaseNote ReleaseNote  `yaml:"relasenote"`
+	Validation   ValidateRule      `yaml:"validation"`
+	ReleaseNote  ReleaseNote       `yaml:"relasenote"`
+	Integrations map[string]string `yaml:"integration"`
 }
 
 func (r *Rule) ValidateTitle(title string) error {
@@ -88,7 +88,7 @@ func (r *Rule) MatchTag(tag string) (bool, error) {
 }
 
 func (r *Rule) Integration() map[string]string {
-	return r.ReleaseNote.Integration
+	return r.Integrations
 }
 
 func (item RuleItem) validate(dat string) error {


### PR DESCRIPTION
This PR modifies some validation processes:

- Support branch filter on validation phase
- move the `integration` field to the root of .doorkeeper.yml