### PR TITLE
Fix logic to check validation branch.

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -72,10 +72,13 @@ func WebhookHandler(prefix string, c *github.Client) http.Handler {
 
 				// When new pullrequest has been opened, run validate and factory relates note
 				case githubPullRequestActionOpened:
-					if !rr.Validation.Disable {
-						go validatePullRequest(c, evt, rr)
-					}
 					if ok, _ := rr.MatchValidateBranch(evt.BaseBranch()); ok {
+						if !rr.Validation.Disable {
+							go validatePullRequest(c, evt, rr)
+						}
+					}
+
+					if ok, _ := rr.MatchReleaseNoteBranch(evt.BaseBranch()); ok {
 						if !rr.ReleaseNote.Disable {
 							go factoryRelaseNotes(c, evt, rr)
 						}
@@ -83,8 +86,10 @@ func WebhookHandler(prefix string, c *github.Client) http.Handler {
 
 				// When pullrequest has been edited, only runs validate
 				case githubPullRequestActionEdited:
-					if !rr.Validation.Disable {
-						go validatePullRequest(c, evt, rr)
+					if ok, _ := rr.MatchValidateBranch(evt.BaseBranch()); ok {
+						if !rr.Validation.Disable {
+							go validatePullRequest(c, evt, rr)
+						}
 					}
 
 				// When pullrequest has been synchronized, only runs factory release notes

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -66,8 +66,8 @@ func (r *Rule) MatchReleaseNoteBranch(branch string) (bool, error) {
 }
 
 func (r *Rule) matchBranch(branch string, targets []string) (bool, error) {
-	for i := range r.ReleaseNote.Branches {
-		if matched, err := regexp.MatchString(r.ReleaseNote.Branches[i], branch); err != nil {
+	for i := range targets {
+		if matched, err := regexp.MatchString(targets[i], branch); err != nil {
 			return false, err
 		} else if matched {
 			return true, nil


### PR DESCRIPTION
## Summary

This PR fix the logic to check validation target branch.

- Fix: targets argument is not used in `Rule.matchBranch()`.
- Fix: check condition on PullRequestActionOpened event.
- Check branch on PullRequestActionEdited event.
