### PR TITLE
rename context name, also send to slack if validation failed

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -28,6 +28,13 @@ const (
 	githubPullRequestActionOpened      = "opened"
 	githubPullRequestActionEdited      = "edited"
 	githubPullRequestActionSynchronize = "synchronize"
+
+	contextNameReleaseNote = "doorkeeper:releasenote"
+	contextNameValidation  = "doorkeeper:validate"
+
+	buildStatusPending = "pending"
+	buildStatusFailure = "failure"
+	buildStatusSuccess = "success"
 )
 
 func WebhookHandler(prefix string, c *github.Client) http.Handler {

--- a/handler/release_note.go
+++ b/handler/release_note.go
@@ -23,7 +23,7 @@ func factoryRelaseNotes(c *github.Client, evt entity.GithubPullRequestEvent, r *
 	// Firstly, create status as "pending"
 	err := c.Status(ctx, evt.StatusURL(), entity.GithubStatus{
 		Status:      "pending",
-		Context:     "grc:relasenote",
+		Context:     "doorkeeper:relasenote",
 		Description: "factoty release note",
 	})
 	if err != nil {
@@ -37,7 +37,7 @@ func factoryRelaseNotes(c *github.Client, evt entity.GithubPullRequestEvent, r *
 			// Update to "failure" status
 			c.Status(ctx, evt.StatusURL(), entity.GithubStatus{
 				Status:      "failure",
-				Context:     "grc:relasenote",
+				Context:     "doorkeeper:relasenote",
 				Description: "factory release note",
 			})
 			return
@@ -45,7 +45,7 @@ func factoryRelaseNotes(c *github.Client, evt entity.GithubPullRequestEvent, r *
 		// Otherwise, update to "success"
 		c.Status(ctx, evt.StatusURL(), entity.GithubStatus{
 			Status:      "success",
-			Context:     "grc:relasenote",
+			Context:     "doorkeeper:relasenote",
 			Description: "factory release note",
 		})
 	}()
@@ -91,12 +91,6 @@ func factoryRelaseNotes(c *github.Client, evt entity.GithubPullRequestEvent, r *
 		)
 	}
 
-	// And add review comment with release note
-	c.Review(ctx, evt.ReviewURL(), entity.GithubReview{
-		Body:  message,
-		Event: "COMMENT",
-	})
-
 	integration := r.Integration()
 	for k, v := range integration {
 		switch k {
@@ -107,4 +101,10 @@ func factoryRelaseNotes(c *github.Client, evt entity.GithubPullRequestEvent, r *
 			}
 		}
 	}
+
+	// And add review comment with release note
+	c.Review(ctx, evt.ReviewURL(), entity.GithubReview{
+		Body:  message,
+		Event: "COMMENT",
+	})
 }

--- a/handler/release_note.go
+++ b/handler/release_note.go
@@ -22,8 +22,8 @@ func factoryRelaseNotes(c *github.Client, evt entity.GithubPullRequestEvent, r *
 
 	// Firstly, create status as "pending"
 	err := c.Status(ctx, evt.StatusURL(), entity.GithubStatus{
-		Status:      "pending",
-		Context:     "doorkeeper:relasenote",
+		Status:      buildStatusPending,
+		Context:     contextNameReleaseNote,
 		Description: "factoty release note",
 	})
 	if err != nil {
@@ -36,16 +36,16 @@ func factoryRelaseNotes(c *github.Client, evt entity.GithubPullRequestEvent, r *
 		if factoryErr != nil {
 			// Update to "failure" status
 			c.Status(ctx, evt.StatusURL(), entity.GithubStatus{
-				Status:      "failure",
-				Context:     "doorkeeper:relasenote",
+				Status:      buildStatusFailure,
+				Context:     contextNameReleaseNote,
 				Description: "factory release note",
 			})
 			return
 		}
 		// Otherwise, update to "success"
 		c.Status(ctx, evt.StatusURL(), entity.GithubStatus{
-			Status:      "success",
-			Context:     "doorkeeper:relasenote",
+			Status:      buildStatusSuccess,
+			Context:     contextNameReleaseNote,
 			Description: "factory release note",
 		})
 	}()

--- a/handler/validate.go
+++ b/handler/validate.go
@@ -19,8 +19,8 @@ func validatePullRequest(c *github.Client, evt entity.GithubPullRequestEvent, r 
 
 	// Firstly, create status as "pending"
 	if err := c.Status(ctx, evt.StatusURL(), entity.GithubStatus{
-		Status:      "pending",
-		Context:     "doorkeeper:validate",
+		Status:      buildStatusPending,
+		Context:     contextNameValidation,
 		Description: "validate pull request",
 	}); err != nil {
 		log.Println("Failed to create status as pending:", err)
@@ -32,8 +32,8 @@ func validatePullRequest(c *github.Client, evt entity.GithubPullRequestEvent, r 
 		if statusErr != nil {
 			// Update to "failure" status
 			if err := c.Status(ctx, evt.StatusURL(), entity.GithubStatus{
-				Status:      "failure",
-				Context:     "doorkeeper:validate",
+				Status:      buildStatusFailure,
+				Context:     contextNameValidation,
 				Description: "validate pull request",
 			}); err != nil {
 				log.Println("Failed to update check status as pending:", err)
@@ -49,8 +49,8 @@ func validatePullRequest(c *github.Client, evt entity.GithubPullRequestEvent, r 
 		}
 		// Otherwise, update to "success"
 		if err := c.Status(ctx, evt.StatusURL(), entity.GithubStatus{
-			Status:      "success",
-			Context:     "doorkeeper:validate",
+			Status:      buildStatusSuccess,
+			Context:     contextNameValidation,
 			Description: "validate pull request",
 		}); err != nil {
 			log.Println("Failed to update shcek status as success:", err)


### PR DESCRIPTION
This PR changes:

- Rename CI build context prefix from `grc` to `doorkeeper`. `grc` is an old name of this project.
- Send to slack if validation fails
- use constant string to avoid typo