### PR TITLE
Trim html comment in release note

### DIFF
--- a/handler/release_note.go
+++ b/handler/release_note.go
@@ -78,7 +78,11 @@ func factoryRelaseNotes(c *github.Client, evt entity.GithubPullRequestEvent, r *
 			stack[prs[j].Number] = struct{}{}
 			matches := releaseSectionRegex.FindStringSubmatch(prs[j].Body)
 			if matches != nil {
-				notes = append(notes, fmt.Sprintf("- #%d %s", prs[j].Number, strings.TrimSpace(matches[1])))
+				notes = append(notes, fmt.Sprintf(
+					"- #%d %s",
+					prs[j].Number,
+					formatReleaseNoteText(matches[1]),
+				))
 			}
 		}
 	}

--- a/handler/util.go
+++ b/handler/util.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"time"
 
 	"crypto/hmac"
@@ -12,6 +13,11 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+)
+
+var (
+	htmlCommentRegex          = regexp.MustCompile(`(?s)<!--\s*.*-->`)
+	unnecessaryCharacterRegex = regexp.MustCompile(`(?s)^[\s\t\r\n]+|[\s\t\r\n]$`)
 )
 
 func successResponse(w http.ResponseWriter) {
@@ -64,4 +70,11 @@ func sendToSlack(ctx context.Context, webhookURL, message string) error {
 	}
 	resp.Body.Close()
 	return nil
+}
+
+func formatReleaseNoteText(txt string) string {
+	return unnecessaryCharacterRegex.ReplaceAllString(
+		htmlCommentRegex.ReplaceAllString(txt, ""),
+		"",
+	)
 }

--- a/handler/util.go
+++ b/handler/util.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	htmlCommentRegex          = regexp.MustCompile(`(?s)<!--\s*.*-->`)
-	unnecessaryCharacterRegex = regexp.MustCompile(`(?s)^[\s\t\r\n]+|[\s\t\r\n]$`)
+	htmlCommentRegex          = regexp.MustCompile(`(?s)<!--\s*([^>]+)?>`)
+	unnecessaryCharacterRegex = regexp.MustCompile(`(?s)^[\s\t\r\n]+|[\s\t\r\n]+$`)
 )
 
 func successResponse(w http.ResponseWriter) {

--- a/handler/util_test.go
+++ b/handler/util_test.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"testing"
+)
+
+func TestFormatReleaseNoteText(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{
+			input:  `Foobar`,
+			expect: `Foobar`,
+		},
+		{
+			input:  `<!-- Put release note here -->Foobar`,
+			expect: `Foobar`,
+		},
+		{
+			input: `
+			<!-- Put release note here -->
+			Foobar
+			<!-- /Put release note here -->
+			`,
+			expect: `Foobar`,
+		},
+	}
+
+	for i, tt := range tests {
+		v := formatReleaseNoteText(tt.input)
+		if v != tt.expect {
+			t.Fatalf(
+				"Test failes for TestFormatReleaseNoteText of %d, expect=%s, actual=%s",
+				i, tt.expect, v,
+			)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes that trims HTML comment inside RELEASE marker tag.

e.g.

Input:
```
<!-- RELEASE -->
<!-- Put Note Here -->
Some feature has implemented
<!-- /RELEASE -->
```

expected note:
```
Some feature has implemented
```