### PR TITLE
provide github secret to handler

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,7 @@ func main() {
 	h := handler.WebhookHandler(
 		handler.WithPrefix("/webhook"),
 		handler.WithClient(client),
+		handler.WithAppSecret(os.Getenv("GITHUB_APP_SECRET")),
 	)
 	log.Printf("Server starts on :%s", port)
 	if err := http.ListenAndServe(":"+port, h); err != nil {


### PR DESCRIPTION
Fix handler responds with 400 on validating GitHub webhook using app secret.